### PR TITLE
correct template option name for clustermq

### DIFF
--- a/hpc.Rmd
+++ b/hpc.Rmd
@@ -161,7 +161,7 @@ drake_hpc_tempalte_file("slurm_clustermq.tmpl") # Write the file slurm_clustermq
 Next, configure [`clustermq`](https://github.com/mschubert/clustermq) to use your scheduler and template file. [`clustermq`](https://github.com/mschubert/clustermq) has a [really nice wiki](https://github.com/mschubert/clustermq/wiki#setting-up-the-scheduler) with more detailed directions.
 
 ```{r clustermqopts, eval = FALSE}
-options(clustermq.scheduler = "slurm", template = "slurm_clustermq.tmpl")
+options(clustermq.scheduler = "slurm", clustermq.template = "slurm_clustermq.tmpl")
 ```
 
 Tip: for a dry run on your local machine, use `options(clustermq.scheduler = "multicore")` instead. Either way, once it is time to run your project, simply call `make()` with one of the [`clustermq`](https://github.com/mschubert/clustermq) parallelism backends.


### PR DESCRIPTION
According to clustermq slurm [docs](https://github.com/mschubert/clustermq/wiki/SLURM), the correct option name is `clustermq.template`, not just `template`.

The same error is present in drake-examples in a c[ouple of places](https://github.com/wlandau/drake-examples/search?q=options+clustermq+template&unscoped_q=options+clustermq+template).