### PR TITLE
Add stuff to the navbar

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -1,4 +1,5 @@
 book_filename: "drake-manual"
+repo: https://github.com/ropenscilabs/drake-manual
 language:
   ui:
     chapter_name: "Chapter "

--- a/_output.yml
+++ b/_output.yml
@@ -1,6 +1,6 @@
 bookdown::gitbook:
   css: https://ropensci.github.io/dev_guide/style.css
-    config:
+  config:
     sharing:
       github: yes
       facebook: false

--- a/_output.yml
+++ b/_output.yml
@@ -15,5 +15,5 @@ bookdown::gitbook:
       link: https://github.com/ropenscilabs/drake-manual/edit/dev/%s
       text: "Edit this chapter"
     history:
-      link: https://github.com/ropenscilabs/drake-manuals/commits/master/%s
+      link: https://github.com/ropenscilabs/drake-manual/commits/master/%s
       text: "Chapter edit history"

--- a/_output.yml
+++ b/_output.yml
@@ -17,3 +17,8 @@ bookdown::gitbook:
     history:
       link: https://github.com/ropenscilabs/drake-manual/commits/master/%s
       text: "Chapter edit history"
+bookdown::pdf_book:
+  includes:
+    in_header: preamble.tex
+  latex_engine: xelatex
+  citation_package: natbib

--- a/_output.yml
+++ b/_output.yml
@@ -1,2 +1,19 @@
 bookdown::gitbook:
   css: https://ropensci.github.io/dev_guide/style.css
+    config:
+    sharing:
+      github: yes
+      facebook: false
+    toc:
+      collapse: subsection
+      before: |
+        <li><a href="./">The drake R Package User Manual</a></li>
+      after: |
+        <li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>
+    download: [pdf]
+    edit:
+      link: https://github.com/ropenscilabs/drake-manual/edit/dev/%s
+      text: "Edit this chapter"
+    history:
+      link: https://github.com/ropenscilabs/drake-manuals/commits/master/%s
+      text: "Chapter edit history"

--- a/preamble.tex
+++ b/preamble.tex
@@ -1,0 +1,18 @@
+\usepackage{booktabs}
+\usepackage{mdframed}
+\usepackage{xcolor}
+\usepackage{hyperref}
+\usepackage[default]{sourcesanspro}
+\definecolor{roblue}{HTML}{6FAEF5}
+\definecolor{rolink}{HTML}{3D98FF}
+\hypersetup
+    {colorlinks=true,
+    linkcolor=rolink,
+urlcolor=rolink,
+filecolor=rolink,
+citecolor=rolink,
+allcolors=rolink
+    }
+\newenvironment{summaryblock}
+    {\begin{mdframed}[linecolor=roblue,linewidth=2pt]}
+    {\end{mdframed}}


### PR DESCRIPTION
# Summary

I'm suggesting adding more info/links to the header.
* Link to the GitHub repo with an icon, on the right.
* PDF download (see the _dev_ dev_guide https://devdevguide.netlify.com/ <- in this case we have a special preamble.tex that you could use but that's not really awesome, just colors for links and summary blocks, and a more modern font). Not sure that is really needed but someone asked us this for the dev_guide.
* Twitter + sharing icons.
* On the left, direct link to edit the page one is reading, and direct link to see the history of that page. Note that there's no hover or so, which is something I've noticed in general with bookdown gitbooks.

# Checklist

- [x] I have read this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/master/NEWS.md).
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.

Regarding the checklist should the last two items disappear/mention the new GitHub feature of draft PRs?
