### PR TITLE
Use aes and .data$ prefix instead of aes_string

### DIFF
--- a/plans.Rmd
+++ b/plans.Rmd
@@ -77,7 +77,7 @@ Some targets may need an update while others may not. In the [walkthrough](#walk
 
 ```{r depscode_plans}
 create_plot <- function(data) {
-  ggplot(data, aes_string(x = "Petal.Width", fill = "Species")) +
+  ggplot(data, aes(x = .data$Petal.Width, fill = .data$Species)) +
     geom_histogram(bins = 20)
 }
 


### PR DESCRIPTION
# Summary

Use `aes()` and `.data$` prefix instead of `aes_string()` because `aes_string` is soft deprecated.

# Checklist

- [o] I understand and agree to this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/master/CONDUCT.md).
- [o] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/master/NEWS.md).
- [o] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
