### PR TITLE
Fix typos in plans.Rmd

### DIFF
--- a/plans.Rmd
+++ b/plans.Rmd
@@ -418,7 +418,7 @@ You can supply your own custom grid using the `.data` argument. Note the use of 
 
 ```{r}
 my_grid <- tibble(
-  sim_function = c("rnrom", "rt", "rcauchy"),
+  sim_function = c("rnorm", "rt", "rcauchy"),
   title = c("Normal", "Student t", "Cauchy")
 )
 my_grid$sim_function <- rlang::syms(my_grid$sim_function)
@@ -463,7 +463,7 @@ drake_plan(
 )
 ```
 
-Things get tricker when `drake` reuses grouping variables from previous transformations. For example, below, each `x_*` target has an associated `nrow` value. So if you write `transform = map(x)`, then `nrow` goes along for the ride.
+Things get tricker when `drake` reuses grouping variables from previous transformations. For example, below, each `x_*` target has an associated `center` value. So if you write `transform = map(x)`, then `center` goes along for the ride.
 
 ```{r}
 drake_plan(


### PR DESCRIPTION
Fixes minor typos in Plans chapter of drake manual (`rnrom` -> `rnorm` and `nrow` -> `center`). 

- [x] I understand and agree to this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/master/CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/master/NEWS.md).
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
