### PR TITLE
fix typo

### DIFF
--- a/static.Rmd
+++ b/static.Rmd
@@ -351,7 +351,7 @@ drake_plan(
 )
 ```
 
-The problems is that there are 4 values of `center` and only two `x_*` targets (and two `y_*` targets). Even if you explicitly supply `center` to the transformation, `map()` can only takes the first two values.
+The problems is that there are 4 values of `center` and only two `x_*` targets (and two `y_*` targets). Even if you explicitly supply `center` to the transformation, `map()` only takes the first two values.
 
 ```{r}
 drake_plan(


### PR DESCRIPTION

# Summary

fixed typo in manual

original sentence: `map()` can only takes the first two values
suggested fix: `map()` only takes the first two values
alternative fix: `map()` can only take the first two values

# Related GitHub issues and pull requests

- none

# Checklist

- [ x ] I understand and agree to this repository's [code of conduct](https://github.com/ropensci/drake-manual/blob/master/CODE_OF_CONDUCT.md).
- [  ] I have listed any substantial changes in the [development news](https://github.com/ropenscilabs/drake-manual/blob/master/NEWS.md).
- [ x ] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
